### PR TITLE
Ensure app can be built on xcode 14, since xcode 15 is in beta

### DIFF
--- a/App/Modules/AppleExport/AppleCalendarExport.swift
+++ b/App/Modules/AppleExport/AppleCalendarExport.swift
@@ -88,6 +88,7 @@ private class AppleCalendarExportService {
     lazy var eventStore: EKEventStore = .init()
 
     func requestAccess(completionHandler: @escaping CalendarExportHandler) {
+        #if swift(>=5.9)
         if #available(iOS 17.0, *) {
             eventStore.requestFullAccessToEvents { granted, error in
                 if granted, error == nil {
@@ -97,6 +98,7 @@ private class AppleCalendarExportService {
                 }
             }
         } else {
+        #endif
             eventStore.requestAccess(to: EKEntityType.event, completion: { granted, error in
                 if granted, error == nil {
                     completionHandler(true)
@@ -104,7 +106,9 @@ private class AppleCalendarExportService {
                     completionHandler(false)
                 }
             })
+        #if swift(>=5.9)
         }
+        #endif
     }
 
     func clearGlucoseEvents() {


### PR DESCRIPTION
upstream PR: https://github.com/creepymonster/GlucoseDirect/pull/564

Previous PR description:
>Currently the following error is reported when building with the latest stable Xcode: Error: Value of type 'EKEventStore' has no member 'requestFullAccessToEvents'.
>
>[requestFullAccessToEvents](https://developer.apple.com/documentation/eventkit/ekeventstore/4162272-requestfullaccesstoevents?changes=lat_6) is a new method only available in iOS 17, which is in beta, and is also only supported by Xcode 15, which is also in beta.
>
>Since this feature is dependent on beta APIs which aren't available on older Xcodes, this application will not build. As a result, this conditional needs additional safeguards in order to compile properly on the latest stable Xcode.
>
>note: Since there isn't a way to check which version of Xcode is used, I needed to check based on the available Swift version, which is published on Apple's documentation: https://developer.apple.com/support/xcode/
>
>Resolves https://github.com/creepymonster/GlucoseDirect/issues/563