### PR TITLE
Visual indication for unavailable stats

### DIFF
--- a/App/Modules/AppleExport/AppleCalendarExport.swift
+++ b/App/Modules/AppleExport/AppleCalendarExport.swift
@@ -88,6 +88,7 @@ private class AppleCalendarExportService {
     lazy var eventStore: EKEventStore = .init()
 
     func requestAccess(completionHandler: @escaping CalendarExportHandler) {
+        #if swift(>=5.9)
         if #available(iOS 17.0, *) {
             eventStore.requestFullAccessToEvents { granted, error in
                 if granted, error == nil {
@@ -97,6 +98,7 @@ private class AppleCalendarExportService {
                 }
             }
         } else {
+        #endif
             eventStore.requestAccess(to: EKEntityType.event, completion: { granted, error in
                 if granted, error == nil {
                     completionHandler(true)
@@ -104,7 +106,9 @@ private class AppleCalendarExportService {
                     completionHandler(false)
                 }
             })
+        #if swift(>=5.9)
         }
+        #endif
     }
 
     func clearGlucoseEvents() {

--- a/App/Views/Lists/StatisticsView.swift
+++ b/App/Views/Lists/StatisticsView.swift
@@ -60,6 +60,8 @@ struct StatisticsView: View {
                         Spacer()
 
                         ForEach(Config.chartLevels, id: \.days) { level in
+                            let levelDisabled = level.days > glucoseStatistics.maxDays
+
                             Spacer()
                             Button(
                                 action: {
@@ -71,16 +73,19 @@ struct StatisticsView: View {
                                         .if(isSelectedChartLevel(days: level.days)) {
                                             $0.fill(Color.ui.label)
                                         } else: {
-                                            $0.stroke(Color.ui.label)
+                                            $0.stroke(levelDisabled ? Color.ui.gray : Color.ui.label )
                                         }
                                         .frame(width: 12, height: 12)
 
                                     Text(verbatim: level.name)
+                                        .if(levelDisabled) {
+                                            $0.strikethrough()
+                                        }
                                         .font(.subheadline)
-                                        .foregroundColor(Color.ui.label)
+                                        .foregroundColor(levelDisabled ? Color.ui.gray : Color.ui.label)
                                 }
                             )
-                            .disabled(level.days > glucoseStatistics.maxDays)
+                            .disabled(levelDisabled)
                             .lineLimit(1)
                             .buttonStyle(.plain)
                         }


### PR DESCRIPTION
upstream PR: https://github.com/creepymonster/GlucoseDirect/pull/569

Previous PR description:

>After using the app, I noticed that statistics were shown after a few days.  When the statistics are shown, I realized un-selectable values were presented with no indication if the options were disabled or not.  This PR changes that.
>
>Before:
>![IMG_4913](https://github.com/creepymonster/GlucoseDirect/assets/5031018/4d3d6d3c-f7ae-413d-a9ef-de4b19669e01)
>
>After:
>![IMG_4914](https://github.com/creepymonster/GlucoseDirect/assets/5031018/05467483-80d3-46f2-bebb-688230155858)